### PR TITLE
Avoid service contracts

### DIFF
--- a/PageAssetsTrait.php
+++ b/PageAssetsTrait.php
@@ -10,7 +10,7 @@ trait PageAssetsTrait
 {
     use AddPageEntrypointTrait;
 
-    protected function getFrontendAsset(): FrontendAsset|null
+    protected function getFrontendAsset(): mixed
     {
         if (!\class_exists(FrontendAsset::class)) {
             return null;

--- a/PageAssetsTrait.php
+++ b/PageAssetsTrait.php
@@ -27,4 +27,20 @@ trait PageAssetsTrait
 
         return null;
     }
+
+    /**
+     * Implement the ServiceSubscriberInterface method to not break existing usages.
+     */
+    public static function getSubscribedServices(): array
+    {
+        $services = \method_exists(\get_parent_class(self::class) ?: '', __FUNCTION__)
+            ? parent::getSubscribedServices()
+            : [];
+
+        if (\class_exists(FrontendAsset::class)) {
+            $services[] = '?'.FrontendAsset::class;
+        }
+
+        return $services;
+    }
 }

--- a/PageAssetsTrait.php
+++ b/PageAssetsTrait.php
@@ -2,70 +2,29 @@
 
 namespace HeimrichHannot\EncoreContracts;
 
+use Contao\System;
 use HeimrichHannot\EncoreBundle\Asset\FrontendAsset;
-use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
-use Psr\Container\NotFoundExceptionInterface;
-use Symfony\Contracts\Service\Attribute\Required;
 
 trait PageAssetsTrait
 {
     use AddPageEntrypointTrait;
 
-    /** @var ContainerInterface $container */
-    protected $container;
-
-    public static function getSubscribedServices(): array
-    {
-        $services = \method_exists(\get_parent_class(self::class) ?: '', __FUNCTION__)
-            ? parent::getSubscribedServices()
-            : [];
-
-        if (\class_exists(FrontendAsset::class)) {
-            $services[] = '?'.FrontendAsset::class;
-        }
-
-        return $services;
-    }
-
-    #[Required]
-    public function setContainer(ContainerInterface $container): ?ContainerInterface
-    {
-        $ret = null;
-        if (\method_exists(\get_parent_class(self::class) ?: '', __FUNCTION__)) {
-            $ret = parent::setContainer($container);
-        }
-
-        $this->container = $container;
-
-        return $ret;
-    }
-
-    /**
-     * @return FrontendAsset|null
-     * @throws ContainerExceptionInterface
-     * @throws NotFoundExceptionInterface
-     */
-    protected function getFrontendAsset(): mixed
+    protected function getFrontendAsset(): FrontendAsset|null
     {
         if (!\class_exists(FrontendAsset::class)) {
             return null;
         }
 
-        if (!isset($this->container)) {
-            return null;
+        if (isset($this->container) && $this->container instanceof ContainerInterface && $this->container->has(FrontendAsset::class)) {
+            return $this->container->get(FrontendAsset::class);
         }
 
-        if (!$this->container->has(FrontendAsset::class)) {
-            return null;
+        if (class_exists(System::class) && System::getContainer()->has(FrontendAsset::class)) {
+            return System::getContainer()->get(FrontendAsset::class);
+
         }
 
-        $service = $this->container->get(FrontendAsset::class);
-
-        if (!$service instanceof FrontendAsset) {
-            return null;
-        }
-
-        return $service;
+        return null;
     }
 }


### PR DESCRIPTION
This PR use the old System class and access the public service container to avoid service contracts issues with the different implementations. In a following PR we should deprecate this stuff and create a new solution based on the new ResponseContext integration.